### PR TITLE
Fix to work with MineClone2

### DIFF
--- a/mob_bed_detection.lua
+++ b/mob_bed_detection.lua
@@ -2,16 +2,18 @@
 -- beds are of special intrest for mobs in some situations (they can sleep there)
 
 -- node names of nodes that are beds
-handle_schematics.bed_node_names = {};
-handle_schematics.bed_node_names['cottages:bed_head'] = 1;
-handle_schematics.bed_node_names['beds:bed_top'] = 1;
-handle_schematics.bed_node_names['beds:fancy_bed_top'] = 1;
-handle_schematics.bed_node_names['cottages:sleeping_mat_head'] = 1;
+handle_schematics.bed_node_names = {
+	['cottages:bed_head']=1,
+	['beds:bed_top']=1,
+	['beds:fancy_bed_top']=1,
+	['cottages:sleeping_mat_head']=1};
 
 -- content ids of nodes that are beds
 handle_schematics.bed_content_ids = {};
 for k,v in pairs( handle_schematics.bed_node_names ) do
-	if( handle_schematics.node_defined( k ) and minetest.get_content_id( k )>0) then
-		handle_schematics.bed_content_ids[ minetest.get_content_id( k ) ] = 1;
+	node_or_replacement = handle_schematics.node_defined( k );
+	if node_or_replacement then
+		content_id = minetest.get_content_id( node_or_replacement.name );
+		handle_schematics.bed_content_ids[ content_id ] = 1;
 	end
 end


### PR DESCRIPTION
The call to get_content_id was failing for nodes in the global_replacement_table (notably 'beds:bed_top'). Lookup now uses the replaced name.